### PR TITLE
Fixed so files can be uploaded

### DIFF
--- a/watson/http/wsgi.py
+++ b/watson/http/wsgi.py
@@ -73,7 +73,7 @@ def get_form_vars(environ, dict_type):
 
 File = collections.namedtuple(
     'File',
-    'data filename name type type_options disposition disposition_options headers')
+    'data filename name type type_options disposition disposition_options headers raw_field')
 
 
 def _process_field_storage(fs, post, files):
@@ -93,7 +93,8 @@ def _process_field_storage(fs, post, files):
                     field.type_options,
                     field.disposition,
                     field.disposition_options,
-                    field.headers)
+                    field.headers,
+                    field)
             else:
                 post[field.name] = field.value
     return post, files


### PR DESCRIPTION
Due to changes in python 3.4 and the FieldStorage object (https://github.com/bottlepy/bottle/issues/567 / http://bugs.python.org/issue18394), when calling the following an exception is thrown because the underlying FileStorage file is __del__'d when accessed

    self.request.files[key].file
    self.request.files[key].filename

So looks like watson.http.messages.Request is unwrapping the FieldStorage and returning it into a “files” tuple, and by the time that hits the controller it's too late and the file has been __del__'d so can't be accessed and stored in the database

Updated so there's now a raw_field in self.request.files, so now you can access the file in the following ways in the controller

    self.request.files[key].raw_field.file

